### PR TITLE
Removed check during install so it always pulls down latest jar file

### DIFF
--- a/init/30_install_davos.sh
+++ b/init/30_install_davos.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-[[ ! -f /app/davos.jar ]] && curl -o /app/davos.jar http://ci.linuxserver.io:8080/job/Davos/job/Release/ws/build/libs/davos-0.0.1-SNAPSHOT.jar
+curl -o /app/davos.jar http://ci.linuxserver.io:8080/job/Davos/job/Release/ws/build/libs/davos-0.0.1-SNAPSHOT.jar
 
 chown abc:abc /app/davos.jar


### PR DESCRIPTION
During these stages of development, the 'update' functionality in restarting the container needs to pull down the .jar file each time. In non-versioned instances at least, as the 'latest' jar could contain new updates.
