### PR TITLE
Rebasing to Alpine 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN \
  chmod 755 /davos.jar
 
 
-FROM lsiobase/alpine:3.8
+FROM lsiobase/alpine:3.9
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -36,7 +36,7 @@ RUN \
  chmod 755 /davos.jar
 
 
-FROM lsiobase/alpine.arm64:3.8
+FROM lsiobase/alpine.arm64:3.9
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -36,7 +36,7 @@ RUN \
  chmod 755 /davos.jar
 
 
-FROM lsiobase/alpine.armhf:3.8
+FROM lsiobase/alpine.armhf:3.9
 
 # set version label
 ARG BUILD_DATE

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -32,4 +32,5 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "22.02.19:", desc: "Rebasing to alpine 3.9." }
   - { date: "18.11.16:", desc: "Initial Release." }


### PR DESCRIPTION
This passed the smoke test of being built and having valid CI:

https://lsio-ci.ams3.digitaloceanspaces.com/lsiodev/davos/2.2.1-pkg-0c4a83b3-dev-ec8c82dac362775bf95a819f92429c0d7295592a/index.html

If you have concern about merging please pull the image above locally and test. Note that qemu sucks for Java blobs, so this has not been intensely tested on arm outside of a boot test. 

